### PR TITLE
RFC 6455 compliance

### DIFF
--- a/lib/webrick/websocket/server.rb
+++ b/lib/webrick/websocket/server.rb
@@ -27,7 +27,7 @@ module WEBrick
         req.path_info = path_info
         si = servlet.get_instance(self, *options)
         @logger.debug(format("%s is invoked.", si.class.name))
-        if req['upgrade'] == 'websocket' && si.is_a?(Servlet)
+        if req['upgrade'].casecmp?('websocket') && si.is_a?(Servlet)
           res.status = 101
           key = req['Sec-WebSocket-Key']
           res['Sec-WebSocket-Accept'] = Digest::SHA1.base64digest(key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')


### PR DESCRIPTION
Treats the |Upgrade| header field as a case-insensitive value. See https://tools.ietf.org/html/rfc6455#section-4.2.1
This fixes compatibility with Apache httpd when using mod_proxy_wstunnel. See https://github.com/apache/httpd/blob/e1384a888c84d725d676bbda20d9020f413553cd/modules/proxy/mod_proxy_wstunnel.c#L329