### PR TITLE
Fixing an error when http requests did not contain 'upgrade'

### DIFF
--- a/lib/webrick/websocket/server.rb
+++ b/lib/webrick/websocket/server.rb
@@ -27,7 +27,7 @@ module WEBrick
         req.path_info = path_info
         si = servlet.get_instance(self, *options)
         @logger.debug(format("%s is invoked.", si.class.name))
-        if req['upgrade'].casecmp?('websocket') && si.is_a?(Servlet)
+        if (req['upgrade'] || '').casecmp?('websocket') && si.is_a?(Servlet)
           res.status = 101
           key = req['Sec-WebSocket-Key']
           res['Sec-WebSocket-Accept'] = Digest::SHA1.base64digest(key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')


### PR DESCRIPTION
Hi, I installed the gem and tried the example you have in the README.md file but I always got an exception, even with a normal http GET request. After tracking down the problem saw that 'upgrade' was not available in req, so I added this small quick fix. Really did not get into more details as this solved my problem, so maybe I'm just fixing the symptoms of the real problem. Anyway, wonder if you could pull this request so that I can install a very little application that I've developed with webrick::websocket to other machines. Thanks a lot for your help!
Regards,
/Hiram